### PR TITLE
fix(security): fix copy-detection workflow broken pipe and output syntax

### DIFF
--- a/.github/workflows/detect_copies.yml
+++ b/.github/workflows/detect_copies.yml
@@ -3,7 +3,7 @@ name: Detect Unauthorized Copies
 on:
   schedule:
     - cron: "0 9 * * 1"  # Every Monday at 9am UTC
-  workflow_dispatch:       # Also allow manual trigger
+  workflow_dispatch:
 
 jobs:
   search-for-copies:
@@ -13,59 +13,58 @@ jobs:
 
     steps:
       - name: Search GitHub for repos containing the watermark
-        id: search
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Search for the unique watermark string across all public GitHub code
-          # The watermark is: callflow-tracer-origin:rajveer43
-          WATERMARK="callflow-tracer-origin:rajveer43"
-          OWNER="rajveer43"
-          REPO="callflow-tracer"
-
-          echo "Searching for watermark: $WATERMARK"
-
-          RESULTS=$(curl -s \
+          curl -s \
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/search/code?q=${WATERMARK}&type=code" \
-          )
+            "https://api.github.com/search/code?q=callflow-tracer-origin:rajveer43&type=code" \
+            > results.json
 
-          echo "$RESULTS" | python3 - <<'PYEOF'
-          import json, sys, os
+      - name: Parse results and check for suspicious repos
+        id: check
+        run: |
+          python3 << 'EOF'
+          import json, os
 
-          data = json.loads(sys.stdin.read())
-          owner = os.environ.get("OWNER", "rajveer43")
-          repo  = os.environ.get("REPO", "callflow-tracer")
+          with open("results.json") as f:
+              data = json.load(f)
+
+          owner = "rajveer43"
+          repo  = "callflow-tracer"
 
           suspicious = []
           for item in data.get("items", []):
               repo_full = item["repository"]["full_name"]
-              # Ignore the original repo and its forks listed under the owner
               if repo_full == f"{owner}/{repo}":
                   continue
-              # GitHub forks are known — flag repos that are NOT listed as forks
-              # (we can't check fork status in code search, so flag all others)
               suspicious.append({
                   "repo": repo_full,
                   "url": item["html_url"],
                   "file": item["path"],
               })
 
-          if suspicious:
-              print("SUSPICIOUS_FOUND=true")
-              lines = ["| Repository | File | Link |", "|---|---|---|"]
-              for s in suspicious:
-                  lines.append(f"| `{s['repo']}` | `{s['file']}` | [view]({s['url']}) |")
-              body = "\n".join(lines)
-              print(f"ISSUE_BODY<<EOF\n{body}\nEOF")
-          else:
-              print("SUSPICIOUS_FOUND=false")
-          PYEOF
+          output_file = os.environ["GITHUB_OUTPUT"]
+          with open(output_file, "a") as f:
+              if suspicious:
+                  f.write("suspicious_found=true\n")
+                  lines = ["| Repository | File | Link |", "|---|---|---|"]
+                  for s in suspicious:
+                      lines.append(f"| `{s['repo']}` | `{s['file']}` | [view]({s['url']}) |")
+                  # Write multi-line output using the delimiter syntax
+                  body = "\n".join(lines)
+                  f.write("issue_body<<DELIM\n")
+                  f.write(body + "\n")
+                  f.write("DELIM\n")
+              else:
+                  f.write("suspicious_found=false\n")
+                  print("No suspicious repos found.")
+          EOF
 
       - name: Open an issue if suspicious repos found
-        if: env.SUSPICIOUS_FOUND == 'true'
+        if: steps.check.outputs.suspicious_found == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -74,10 +73,10 @@ jobs:
             --title "⚠️ Possible unauthorized copy detected ($(date +%Y-%m-%d))" \
             --body "The weekly copy-detection scan found the repository watermark in repos other than the origin.
 
-          ${{ env.ISSUE_BODY }}
+          ${{ steps.check.outputs.issue_body }}
 
           **Next steps:**
           - Check if these are legitimate forks listed under your GitHub fork network
-          - If not a fork, review the repo and consider filing a DMCA takedown via GitHub: https://support.github.com/contact/dmca-takedown
+          - If not a fork, consider filing a DMCA takedown: https://support.github.com/contact/dmca-takedown
           " \
             --label "security"


### PR DESCRIPTION
## What broke
The `detect_copies.yml` workflow was failing with:
- `echo: write error: Broken pipe` — Python heredoc inside shell `run:` block conflicted with the piped curl output
- `JSONDecodeError` — curl output never reached the Python script
- Env vars set via `print()` to stdout don't work in GitHub Actions

## What was fixed
- Split into two steps: curl saves to `results.json`, Python reads the file separately
- Python script no longer uses a heredoc — uses a plain `<< 'EOF'` block cleanly
- Outputs now written to `$GITHUB_OUTPUT` using the proper delimiter syntax for multi-line values